### PR TITLE
docs: clarify stateless execution model in template, prompt, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ Update competitor-last.md with current state.
 If nothing new or nothing worth proposing, HEARTBEAT_OK.
 ```
 
+## Execution Model
+
+Each heartbeat is a fresh Claude CLI invocation. There is no conversation history or memory between runs — Claude starts from scratch every time.
+
+This is intentional: it prevents context bloat, keeps behavior predictable, and means a single bad run can't corrupt future ones.
+
+**To persist state between heartbeats, use files.** Claude can read and write files in the workspace directory. Common patterns:
+
+- **Track processed items** — write seen IDs to `.heartbeat-state.json` so you don't re-process them
+- **Detect changes** — save the previous state to a file and diff against the current state on the next run
+- **Accumulate results** — append to a log file or markdown document across runs
+
+The price monitor and competitor watch examples above both demonstrate this pattern.
+
 ## Config
 
 `~/.murmur/config.json` — workspaces and their schedules.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -330,7 +330,13 @@ function cliEmitter(event: DaemonEvent) {
   }
 }
 
-const HEARTBEAT_TEMPLATE = `# Heartbeat
+const HEARTBEAT_TEMPLATE = `<!--
+  Each heartbeat runs in a fresh Claude session with NO memory of previous runs.
+  To persist state between heartbeats, read/write files in this directory or use git.
+  Example: track processed item IDs in .heartbeat-state.json
+-->
+
+# Heartbeat
 
 What to do on each heartbeat. If nothing needs attention, respond with
 exactly \`HEARTBEAT_OK\`. Otherwise, start with \`ATTENTION:\` and a brief summary.

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -26,6 +26,8 @@ export async function buildPrompt(ws: WorkspaceConfig): Promise<string> {
 WORKSPACE: ${ws.path}
 TIME: ${new Date().toISOString()}
 
+This is a fresh session. You have no memory of previous runs. To persist state between heartbeats, read/write files in the workspace.
+
 ---
 ${contents}
 ---


### PR DESCRIPTION
Closes #20

## Summary
- Added HTML comment to HEARTBEAT.md template explaining that each run is a fresh session with no memory of previous runs, with guidance on using files for state persistence
- Added one-line stateless reminder to the system prompt in `buildPrompt()` so every agent session starts with this context
- Added "Execution Model" section to README between HEARTBEAT.md examples and Config, explaining the stateless architecture and common state persistence patterns

## Test plan
- [x] Unit tests pass (`bun test src/`)
- [x] Build succeeds (`bun run build`)
- [ ] Verify `murmur init` creates HEARTBEAT.md with the new comment block
- [ ] Verify heartbeat prompt includes the stateless reminder line

🤖 Generated with [Claude Code](https://claude.com/claude-code)