### PR TITLE
fix(agents): spawn processes in login shell for PATH resolution

### DIFF
--- a/e2e-tests/login-shell-e2e.test.ts
+++ b/e2e-tests/login-shell-e2e.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DEBUG_LOG_FILENAME } from "../src/debug.ts";
+
+/**
+ * E2E tests for login shell wrapping (issue #42).
+ *
+ * Verifies that when murmur spawns agent processes, it wraps them in
+ * the user's login shell (`$SHELL -lc`) so that PATH modifications
+ * from .zshrc/.bash_profile are available — critical for detached daemon mode.
+ *
+ * Requirements:
+ *   - Compiled murmur binary (run `bun run build` first)
+ *   - `claude` CLI installed and authenticated
+ */
+
+const REPO_DIR = join(import.meta.dir, "..");
+const MURMUR_BIN = join(REPO_DIR, "murmur");
+
+let testDataDir: string;
+
+async function murmur(...args: string[]) {
+  const proc = Bun.spawn([MURMUR_BIN, "--data-dir", testDataDir, "--debug", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 120_000,
+  });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  return { exitCode, stdout, stderr };
+}
+
+function readDebugLog(): string {
+  const logPath = join(testDataDir, DEBUG_LOG_FILENAME);
+  if (!existsSync(logPath)) return "";
+  return readFileSync(logPath, "utf-8");
+}
+
+beforeAll(() => {
+  if (!existsSync(MURMUR_BIN)) {
+    throw new Error(`Compiled binary not found at ${MURMUR_BIN}. Run "bun run build" first.`);
+  }
+  testDataDir = mkdtempSync(join(tmpdir(), "murmur-login-shell-e2e-"));
+});
+
+describe("login shell wrapping e2e", () => {
+  test("agent spawn uses login shell wrapper", async () => {
+    // Create a minimal workspace that completes quickly
+    const wsDir = join(testDataDir, "ws");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(wsDir, { recursive: true });
+    writeFileSync(
+      join(wsDir, "HEARTBEAT.md"),
+      `---
+agent: claude-code
+model: haiku
+maxTurns: 5
+---
+
+Say HEARTBEAT_OK. Do not run any commands.
+`,
+    );
+
+    const result = await murmur("beat", wsDir);
+    expect(result.exitCode).toBe(0);
+
+    // The debug log should show the login shell wrapping
+    const debugLog = readDebugLog();
+
+    // shell.ts logs: "[shell] Wrapping command in login shell: <shell> -lc ..."
+    expect(debugLog).toContain("[shell] Wrapping command in login shell:");
+    expect(debugLog).toContain("-lc");
+
+    // The spawn line should show the wrapped command, not bare "claude"
+    const spawnLine = debugLog.split("\n").find((l) => l.includes("Spawning:"));
+    expect(spawnLine).toBeDefined();
+    // The original claude args should still appear in the spawn debug line
+    expect(spawnLine).toContain("claude");
+  }, 120_000);
+
+  test("login shell wrapping also applies to isCommandAvailable", async () => {
+    // Create a workspace with an unavailable agent to test the availability check path
+    const wsDir = join(testDataDir, "ws-unavailable");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(wsDir, { recursive: true });
+    writeFileSync(
+      join(wsDir, "HEARTBEAT.md"),
+      `---
+agent: claude-code
+model: haiku
+---
+
+Say HEARTBEAT_OK.
+`,
+    );
+
+    // Run beat — even if it succeeds, the debug log will show the login shell wrapping
+    // for the `which claude` availability check
+    await murmur("beat", wsDir);
+
+    const debugLog = readDebugLog();
+    // The shell wrapper logs for the `which` command used in isCommandAvailable
+    expect(debugLog).toContain("[shell] Wrapping command in login shell:");
+  }, 120_000);
+});

--- a/src/agents/claude-code.ts
+++ b/src/agents/claude-code.ts
@@ -3,6 +3,7 @@ import { buildDisallowedToolsArgs } from "../permissions.ts";
 import { runParseStream } from "../stream-parser.ts";
 import { isCommandAvailable, getCommandVersion } from "./cli-utils.ts";
 import { DEFAULT_MAX_TURNS, resolveTimeoutMs } from "./constants.ts";
+import { wrapInLoginShell } from "./shell.ts";
 import type { AgentAdapter, AgentExecutionResult, AgentStreamCallbacks } from "./adapter.ts";
 import type { WorkspaceConfig } from "../types.ts";
 
@@ -44,7 +45,8 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
     debug(`[claude-code] Spawning: ${claudeArgs.join(" ")} (cwd: ${workspace.path})`);
 
-    const proc = Bun.spawn(claudeArgs, {
+    const wrappedCmd = wrapInLoginShell(claudeArgs);
+    const proc = Bun.spawn(wrappedCmd, {
       cwd: workspace.path,
       stdin: new Blob([prompt]),
       stdout: "pipe",

--- a/src/agents/cli-utils.ts
+++ b/src/agents/cli-utils.ts
@@ -1,13 +1,16 @@
 import { debug } from "../debug.ts";
+import { wrapInLoginShell } from "./shell.ts";
 
 /**
  * Check if a CLI command is available on the system.
+ * Uses login shell to ensure full PATH is available.
  * @param command The command name (e.g., "claude", "pi", "aider")
  * @returns true if the command is found in PATH
  */
 export async function isCommandAvailable(command: string): Promise<boolean> {
   try {
-    const proc = Bun.spawn(["which", command], {
+    const wrappedCmd = wrapInLoginShell(["which", command]);
+    const proc = Bun.spawn(wrappedCmd, {
       stdout: "pipe",
       stderr: "ignore",
     });
@@ -23,6 +26,7 @@ export async function isCommandAvailable(command: string): Promise<boolean> {
 
 /**
  * Get the version string of a CLI command.
+ * Uses login shell to ensure full PATH is available.
  * @param command The command name
  * @param flag The version flag (default: "--version")
  * @returns Version string or null if unavailable
@@ -32,7 +36,8 @@ export async function getCommandVersion(
   flag = "--version",
 ): Promise<string | null> {
   try {
-    const proc = Bun.spawn([command, flag], {
+    const wrappedCmd = wrapInLoginShell([command, flag]);
+    const proc = Bun.spawn(wrappedCmd, {
       stdout: "pipe",
       stderr: "ignore",
     });

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -2,6 +2,7 @@ import { debug, truncateForLog } from "../debug.ts";
 import { runCodexParseStream } from "../codex-stream-parser.ts";
 import { isCommandAvailable, getCommandVersion } from "./cli-utils.ts";
 import { resolveTimeoutMs } from "./constants.ts";
+import { wrapInLoginShell } from "./shell.ts";
 import type { AgentAdapter, AgentExecutionResult, AgentStreamCallbacks } from "./adapter.ts";
 import type { WorkspaceConfig, CodexConfig } from "../types.ts";
 
@@ -84,7 +85,8 @@ export class CodexAdapter implements AgentAdapter {
 
     debug(`[codex] Spawning: ${codexArgs.join(" ")} (cwd: ${workspace.path})`);
 
-    const proc = Bun.spawn(codexArgs, {
+    const wrappedCmd = wrapInLoginShell(codexArgs);
+    const proc = Bun.spawn(wrappedCmd, {
       cwd: workspace.path,
       stdin: new Blob([prompt]),
       stdout: "pipe",

--- a/src/agents/pi.ts
+++ b/src/agents/pi.ts
@@ -1,6 +1,7 @@
 import { debug } from "../debug.ts";
 import { isCommandAvailable, getCommandVersion } from "./cli-utils.ts";
 import { resolveTimeoutMs } from "./constants.ts";
+import { wrapInLoginShell } from "./shell.ts";
 import { streamPlainTextProcess } from "./plain-text-stream.ts";
 import type { AgentAdapter, AgentExecutionResult, AgentStreamCallbacks } from "./adapter.ts";
 import type { WorkspaceConfig, PiConfig } from "../types.ts";
@@ -66,7 +67,8 @@ export class PiAdapter implements AgentAdapter {
 
     debug(`[pi] Spawning: ${piArgs.join(" ")} (cwd: ${workspace.path})`);
 
-    const proc = Bun.spawn(piArgs, {
+    const wrappedCmd = wrapInLoginShell(piArgs);
+    const proc = Bun.spawn(wrappedCmd, {
       cwd: workspace.path,
       stdin: new Blob([prompt]),
       stdout: "pipe",

--- a/src/agents/shell.test.ts
+++ b/src/agents/shell.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { wrapInLoginShell } from "./shell.ts";
+
+describe("wrapInLoginShell", () => {
+  const originalPlatform = process.platform;
+  const originalShell = process.env.SHELL;
+
+  afterEach(() => {
+    // Restore original values
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      writable: true,
+      configurable: true,
+    });
+    if (originalShell) {
+      process.env.SHELL = originalShell;
+    } else {
+      delete process.env.SHELL;
+    }
+  });
+
+  test("wraps command in login shell on Unix (macOS)", () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+      configurable: true,
+    });
+    process.env.SHELL = "/bin/zsh";
+
+    const result = wrapInLoginShell(["claude", "--version"]);
+    expect(result).toEqual(["/bin/zsh", "-lc", "'claude' '--version'"]);
+  });
+
+  test("wraps command in login shell on Unix (Linux)", () => {
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      writable: true,
+      configurable: true,
+    });
+    process.env.SHELL = "/bin/bash";
+
+    const result = wrapInLoginShell(["pi", "--help"]);
+    expect(result).toEqual(["/bin/bash", "-lc", "'pi' '--help'"]);
+  });
+
+  test("returns original command on Windows", () => {
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      writable: true,
+      configurable: true,
+    });
+
+    const result = wrapInLoginShell(["claude", "--version"]);
+    expect(result).toEqual(["claude", "--version"]);
+  });
+
+  test("falls back to /bin/sh when SHELL is not set", () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+      configurable: true,
+    });
+    delete process.env.SHELL;
+
+    const result = wrapInLoginShell(["codex", "exec"]);
+    expect(result).toEqual(["/bin/sh", "-lc", "'codex' 'exec'"]);
+  });
+
+  test("handles empty command array", () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+      configurable: true,
+    });
+    process.env.SHELL = "/bin/zsh";
+
+    const result = wrapInLoginShell([]);
+    expect(result).toEqual([]);
+  });
+
+  test("escapes single quotes in arguments", () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+      configurable: true,
+    });
+    process.env.SHELL = "/bin/bash";
+
+    const result = wrapInLoginShell(["echo", "it's working"]);
+    expect(result).toEqual(["/bin/bash", "-lc", "'echo' 'it'\\''s working'"]);
+  });
+
+  test("handles arguments with spaces", () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+      configurable: true,
+    });
+    process.env.SHELL = "/bin/zsh";
+
+    const result = wrapInLoginShell(["claude", "--prompt", "hello world"]);
+    expect(result).toEqual(["/bin/zsh", "-lc", "'claude' '--prompt' 'hello world'"]);
+  });
+
+  test("handles arguments with special characters", () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+      configurable: true,
+    });
+    process.env.SHELL = "/bin/bash";
+
+    const result = wrapInLoginShell(["echo", "$HOME", "$(pwd)", "`ls`"]);
+    expect(result).toEqual(["/bin/bash", "-lc", "'echo' '$HOME' '$(pwd)' '`ls`'"]);
+  });
+
+  test("handles complex multi-arg commands", () => {
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      writable: true,
+      configurable: true,
+    });
+    process.env.SHELL = "/bin/bash";
+
+    const result = wrapInLoginShell([
+      "codex",
+      "exec",
+      "--sandbox",
+      "workspace-write",
+      "--model",
+      "o1",
+      "-",
+    ]);
+    expect(result).toEqual([
+      "/bin/bash",
+      "-lc",
+      "'codex' 'exec' '--sandbox' 'workspace-write' '--model' 'o1' '-'",
+    ]);
+  });
+});

--- a/src/agents/shell.ts
+++ b/src/agents/shell.ts
@@ -1,0 +1,69 @@
+import { debug } from "../debug.ts";
+
+/**
+ * Escape a shell argument for safe use in a shell command string.
+ * Wraps the argument in single quotes and escapes any single quotes within it.
+ *
+ * @param arg The argument to escape
+ * @returns Escaped argument safe for shell execution
+ */
+function escapeShellArg(arg: string): string {
+  // Replace single quotes with '\'' (end quote, escaped quote, start quote)
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Check if we should use login shell wrapping based on the platform.
+ * Login shell is only used on Unix-like systems (macOS, Linux).
+ *
+ * @returns true if login shell should be used
+ */
+function shouldUseLoginShell(): boolean {
+  const platform = process.platform;
+  return platform !== "win32";
+}
+
+/**
+ * Get the user's login shell from environment, with fallback.
+ *
+ * @returns Path to the shell executable
+ */
+function getLoginShell(): string {
+  return process.env.SHELL || "/bin/sh";
+}
+
+/**
+ * Wrap a command array for execution through a login shell.
+ * On Unix-like systems (macOS, Linux), spawns through `$SHELL -lc "command args..."`.
+ * On Windows or when $SHELL is not set, returns the original command array.
+ *
+ * This ensures the spawned process inherits the user's full environment (PATH, etc.)
+ * including modifications from .bash_profile, .zshrc, etc.
+ *
+ * @param command Command array (e.g., ["claude", "--version"])
+ * @returns Wrapped command array for Bun.spawn
+ *
+ * @example
+ * ```ts
+ * // On macOS/Linux with $SHELL=/bin/zsh:
+ * wrapInLoginShell(["claude", "--version"])
+ * // Returns: ["/bin/zsh", "-lc", "'claude' '--version'"]
+ *
+ * // On Windows:
+ * wrapInLoginShell(["claude", "--version"])
+ * // Returns: ["claude", "--version"]
+ * ```
+ */
+export function wrapInLoginShell(command: string[]): string[] {
+  if (!shouldUseLoginShell() || command.length === 0) {
+    return command;
+  }
+
+  const shell = getLoginShell();
+  const escapedArgs = command.map(escapeShellArg);
+  const commandString = escapedArgs.join(" ");
+
+  debug(`[shell] Wrapping command in login shell: ${shell} -lc ${commandString}`);
+
+  return [shell, "-lc", commandString];
+}

--- a/src/agents/shell.ts
+++ b/src/agents/shell.ts
@@ -1,5 +1,8 @@
 import { debug } from "../debug.ts";
 
+/** Default fallback shell when $SHELL is not set */
+const DEFAULT_SHELL = "/bin/sh";
+
 /**
  * Escape a shell argument for safe use in a shell command string.
  * Wraps the argument in single quotes and escapes any single quotes within it.
@@ -29,7 +32,7 @@ function shouldUseLoginShell(): boolean {
  * @returns Path to the shell executable
  */
 function getLoginShell(): string {
-  return process.env.SHELL || "/bin/sh";
+  return process.env.SHELL || DEFAULT_SHELL;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #42: Detached daemon now spawns agent processes through the user's login shell, ensuring full PATH resolution.

When murmur runs as a detached daemon (`murmur start --detach`), agent processes (claude, codex, pi) are spawned directly via `Bun.spawn()`, which inherits only the minimal environment from the daemon process. This causes CLIs installed in non-standard PATH locations to not be found.

## Changes

- **New utility** (`src/agents/shell.ts`): `wrapInLoginShell()` wraps commands in `$SHELL -lc "command args..."` on Unix systems
- **All agent adapters** (`claude-code.ts`, `codex.ts`, `pi.ts`): Use shell wrapper for process spawning
- **CLI utilities** (`cli-utils.ts`): Use shell wrapper for availability checks and version detection
- **Comprehensive tests** (`shell.test.ts`): Test escaping, platform detection, and edge cases
- **Platform-specific**: Only applies on macOS/Linux; Windows uses direct spawn

## Benefits

- Resolves PATH issues for Homebrew-installed CLIs on Apple Silicon (`/opt/homebrew/bin`)
- Supports Node.js version managers (`nvm`, `volta`, `fnm`)
- Works with user-local installs (`~/.local/bin`, `~/.cargo/bin`)

## Test Plan

- [x] Unit tests pass (`bun run test`)
- [x] Type checking and linting pass (`bun run check`)
- [x] New shell utility has comprehensive test coverage
- [x] All agent adapters updated consistently

Closes #42

Generated with [Claude Code](https://claude.com/claude-code)